### PR TITLE
1. 인증(로그인성공) 된 유저의 신분증(AccountDetails) 에 String m_type 추가

### DIFF
--- a/FinalProject/src/main/java/com/alj/dream/member/controller/SwitchTypeController.java
+++ b/FinalProject/src/main/java/com/alj/dream/member/controller/SwitchTypeController.java
@@ -1,0 +1,37 @@
+package com.alj.dream.member.controller;
+
+import java.io.IOException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import security.AccountDetails;
+
+// 멘토/멘티 전환 요청을 처리하는 SwitchTypeController
+@Controller
+@RequestMapping("/member/switchType")
+public class SwitchTypeController {
+	
+	@GetMapping
+	public void switchType(HttpServletRequest req, HttpServletResponse resp, Authentication authentication) throws IOException {
+		//System.out.println(req.getHeader("referer"));
+		
+		// 유저의 허가증 객체를 받아 멘토일시 멘티로 멘티일시 멘토로 변경한다.
+		AccountDetails logininfo=(AccountDetails)authentication.getPrincipal();
+	
+//		System.out.println(logininfo==null);
+//		System.out.println(logininfo.getM_type());
+		
+		logininfo.setM_type(logininfo.getM_type().equals("mentee")?"mentoor":"mentee");
+		
+		// 보던 페이지로 리다이렉트
+		resp.sendRedirect(req.getHeader("referer"));
+	}
+	
+
+}

--- a/FinalProject/src/main/java/security/AccountDetails.java
+++ b/FinalProject/src/main/java/security/AccountDetails.java
@@ -11,7 +11,20 @@ public class AccountDetails extends User{
 	
 	private String photo;
 	private String name;
+	private String m_type;
 
+	public AccountDetails(String username, String password, boolean enabled, boolean accountNonExpired,
+			boolean credentialsNonExpired, boolean accountNonLocked,
+			Collection<? extends GrantedAuthority> authorities, String photo, String name, String m_type) {
+		
+		
+		super(username, password, enabled, accountNonExpired, credentialsNonExpired, accountNonLocked, authorities);
+		this.photo = photo;
+		this.name=name;
+		this.m_type=m_type;
+		
+	}
+	
 	public AccountDetails(String username, String password, boolean enabled, boolean accountNonExpired,
 			boolean credentialsNonExpired, boolean accountNonLocked,
 			Collection<? extends GrantedAuthority> authorities, String photo, String name) {
@@ -20,9 +33,9 @@ public class AccountDetails extends User{
 		super(username, password, enabled, accountNonExpired, credentialsNonExpired, accountNonLocked, authorities);
 		this.photo = photo;
 		this.name=name;
-		
-		
 	}
+	
+	
 
 	public String getPhoto() {
 		return photo;
@@ -38,6 +51,16 @@ public class AccountDetails extends User{
 
 	public void setName(String name) {
 		this.name = name;
+	}
+	
+	
+
+	public String getM_type() {
+		return m_type;
+	}
+
+	public void setM_type(String m_type) {
+		this.m_type = m_type;
 	}
 
 	@Override

--- a/FinalProject/src/main/java/security/AccountService.java
+++ b/FinalProject/src/main/java/security/AccountService.java
@@ -70,7 +70,7 @@ public class AccountService implements UserDetailsService {
 				if(vo==null) {
 					throw new UsernameNotFoundException("회원 정보가 없습니다.");
 				}
-				userDetails=new AccountDetails(vo.getM_email(), vo.getM_password(),true, true,true,true,getRoleList(vo.getRole()),vo.getM_photo(), vo.getM_nm());
+				userDetails=new AccountDetails(vo.getM_email(), vo.getM_password(),true, true,true,true,getRoleList(vo.getRole()),vo.getM_photo(), vo.getM_nm(),"mentee");
 			}
 			}catch(Exception e) {
 				e.printStackTrace();

--- a/FinalProject/src/main/webapp/WEB-INF/views/home/home.jsp
+++ b/FinalProject/src/main/webapp/WEB-INF/views/home/home.jsp
@@ -47,12 +47,42 @@
 		<h1><sec:authorize access="isAnonymous()">비회원입니다.</sec:authorize>	 </h1>
 		<h1><sec:authorize access="hasRole('GENERAL')">회원입니다.</sec:authorize>	 </h1>
 		<h1><sec:authorize access="isAuthenticated()">인증은 되었습니다.</sec:authorize> </h1>
+		<%-- <h1>멘토/멘티 상태 : <sec:authentication property="m_type"/></h1> --%>
 		
 		
 		
 		
-   <!-- end of global wrap div -->
+    <!-- end of global wrap div -->
     </div>
+    
+    <!--  test area -->
+    <div class="container" style="border: 1px solid black">
+    
+    	<!--  인증된 유저 = 로그인에 성공한 유저만 이 메뉴를 볼 수 있다 -->
+    	<sec:authorize access="isAuthenticated()">
+    	
+	    	<!-- 허가증의 m_type 변수명을 type 으로 설정 -->
+	    	<!-- jstl 표현식에서 type 을 사용하여 간편히 처리하기 위함 -->
+	    	<c:set var="type">
+	    		<sec:authentication property="principal.m_type"/>
+	    	</c:set>
+	    	
+	    		<h4>현재 회원님의 상태는 ${type} 입니다</h4>
+	    	
+	    		<c:if test="${type eq 'mentee'}">
+	    			<span class="changeType">멘토로전환</span>
+		    	</c:if>
+		    	
+		    	<c:if test="${type eq 'mentoor'}">
+		    		<span class="changeType">멘티로전환</span>
+		    	</c:if>
+    	
+    	</sec:authorize>
+    	
+    	
+    	
+    </div>
+    <!-- end of test area -->
     
     
     <!-- footer -->
@@ -66,4 +96,5 @@
     
    
 </body>
+
 </html>

--- a/FinalProject/src/main/webapp/WEB-INF/views/home/pageset/homepageset.jsp
+++ b/FinalProject/src/main/webapp/WEB-INF/views/home/pageset/homepageset.jsp
@@ -48,6 +48,12 @@
   	        	  
   	        	  location.href="${pageContext.request.contextPath}/logout";
   	          })
+  	          
+  	          
+  	          $('.changeType').on('click',function(){
+  	        	  
+  	        	  location.href="${pageContext.request.contextPath}/member/switchType"
+  	          })
     	
     })
     


### PR DESCRIPTION
2. 관리자일시 m_type 없음

3. SwitchTypeController 는 현재 유저(AccountDetails logininfo) 의 m_type 에 따라
멘토일시 멘티로, 멘티일시 멘토로 전환하고 보던 페이지로 리다이렉팅하는 컨트롤러

요청 url 은 /member/switchType


home.jsp 에 멘토/멘티 전환 기능에 대해 테스트 링크들을 추가하였음